### PR TITLE
437_path_sum_iii

### DIFF
--- a/437_path_sum_iii.cpp
+++ b/437_path_sum_iii.cpp
@@ -1,0 +1,33 @@
+class Solution {
+public:
+    int count;
+    
+    void dfs(TreeNode* root, long long sum,  long long  targetSum)
+    {
+        if(root==NULL)
+            return;
+        sum+=root->val;
+        if(sum==targetSum)
+        {
+            count++;
+        }
+        dfs(root->left, sum, targetSum);
+        dfs(root->right, sum, targetSum);
+    }
+     
+    void rec(TreeNode* root, long long targetSum)
+    {
+        if(root == NULL)
+            return ;
+        dfs(root, 0, targetSum);
+        rec(root->left, targetSum);
+        rec(root->right, targetSum);
+    }
+    
+    int pathSum(TreeNode* root, int targetSum) {
+        count =0;
+        // call recusrion 
+        rec(root,targetSum);
+        return count;
+    }
+};


### PR DESCRIPTION
Problem: 

Given the root of a binary tree and an integer targetSum, return the number of paths where the sum of the values along the path equals targetSum.
The path does not need to start or end at the root or a leaf, but it must go downwards (i.e., traveling only from parent nodes to child nodes).

Solution : Created 437_path_sum_iii.cpp